### PR TITLE
Enforce LF line endings

### DIFF
--- a/src/SourceTools.jl
+++ b/src/SourceTools.jl
@@ -16,7 +16,7 @@ Represent Julia-flavoured HAML source code that can be parsed using
 the `Meta.parse` function.
 """
 Source(__source__::LineNumberNode, text::AbstractString) = Source(__source__, text, 1)
-Source(path::AbstractString) = Source(LineNumberNode(1, Symbol(path)), read(path, String), 1)
+Source(path::AbstractString) = Source(LineNumberNode(1, Symbol(path)), replace(read(path, String), r"\r\n"=>'\n'), 1)
 
 function linecol(s::Source, ix::Int=s.ix)
     line, col = 1, 1


### PR DESCRIPTION
Currently, on Windows where git automatically converts LF to CRLF, current matching algorithms will fail spuriously. This patch converts the line endings to allow them work.